### PR TITLE
Make PyPI publish step idempotent (skip-existing: true)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,3 +94,5 @@ jobs:
           path: dist
           merge-multiple: true
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true


### PR DESCRIPTION
## Summary
Adds `skip-existing: true` to `pypa/gh-action-pypi-publish` in `release.yml`. The action now returns success when a file already exists on PyPI instead of erroring with HTTP 400.

## Why
v1.0.1's first successful publish run uploaded all six artifacts. A subsequent re-run (or a partially-completed run that the user retries) tries to re-upload the same files, and PyPI rejects file reuse with `400 Bad Request`. Without `skip-existing`, that second run is marked failed even though the release is fully shipped — noisy and confusing.

With `skip-existing`, future re-runs are no-ops if the version is already published, and partial uploads can be safely retried.

## Test plan
- [ ] PR merged
- [ ] Future tag re-runs (intentional or accidental) on already-published versions show as green instead of failing on duplicate-file 400