### PR TITLE
Auto-create GitHub Release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,12 @@ jobs:
     needs: [linux, macos, windows, sdist]
     if: startsWith(github.ref, 'refs/tags/v')
     environment: pypi
+    permissions:
+      id-token: write    # required for OIDC trusted publishing
+      contents: write    # required for the GitHub Release step below
     steps:
+      - name: Checkout (for CHANGELOG.md)
+        uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           path: dist
@@ -96,3 +101,28 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
+
+      - name: Extract release notes from CHANGELOG.md
+        # Pulls the section bounded by `## <ver>` (bracket-tolerant) and
+        # the next `## ` heading. Falls back to a tag-commits link if
+        # the heading is missing or CHANGELOG.md doesn't exist.
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          if [ -f CHANGELOG.md ]; then
+            awk -v ver="$VER" '
+              $0 ~ "^## \\[?" ver "\\]?( |$)" { found=1; next }
+              found && /^## / { exit }
+              found { print }
+            ' CHANGELOG.md > release-notes.md
+          fi
+          [ -s release-notes.md ] || echo "See [tag commits](https://github.com/${GITHUB_REPOSITORY}/commits/${GITHUB_REF_NAME})." > release-notes.md
+
+      - name: Create GitHub Release
+        # Idempotent: updates an existing Release for this tag rather
+        # than erroring, so manual pre-creation never blocks a re-run.
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          body_path: release-notes.md
+          generate_release_notes: true
+          files: dist/*


### PR DESCRIPTION
## Summary

Pushing a `v*` tag publishes to PyPI but does **not** create an entry on the GitHub Releases page. This PR closes that gap: the `publish` job in `release.yml` now also creates a GitHub Release, with the matching `## <version>` section of `CHANGELOG.md` as the body and all wheels + sdist attached as assets.

Identical pattern to:
- mstorath/CircleMedianFilter#6
- mstorath/Pottslab#5
- (parallel PRs in L1TV, DCEBE)

## How it works

In the existing `publish` job, after the PyPI upload:

1. `actions/checkout@v4` puts `CHANGELOG.md` on disk.
2. An awk one-liner extracts the `## <ver>` section verbatim — bracket-tolerant so it accepts both `## [1.0.1] - date` and `## 1.0.1 — date`. Falls back to a tag-commits link if nothing matches.
3. `softprops/action-gh-release@v2` creates the Release with that as the body, attaches `dist/*`, and stacks `generate_release_notes: true` on top for an auto-generated PR/commit summary.

Job-level `permissions` block added (replaces top-level inherit): `id-token: write` for OIDC + `contents: write` for the release action.

Idempotent: updates in place if a Release for the tag already exists.

## Test plan

- [ ] Awk extraction tested against current `CHANGELOG.md` locally — the `## [1.0.1]` heading matches.
- [ ] First real exercise: next `v*` tag push.
- [ ] No effect on the build/sdist/publish-to-PyPI jobs themselves.