### PR TITLE
Add post-publish verify step (real install + import + call)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,3 +126,21 @@ jobs:
           body_path: release-notes.md
           generate_release_notes: true
           files: dist/*
+
+      - name: Verify uploaded package (real install + import + call)
+        # Defends against silent failures where PyPI accepts the upload
+        # but the package isn't actually usable (renamed module, missing
+        # __init__, broken native binding, ABI mismatch, etc.).
+        # Mirrors CMF v0.1.7's step — see devcontainer reports/11.
+        run: |
+          # Brief delay so PyPI's CDN settles the new version.
+          sleep 30
+          pip install --no-cache-dir --index-url https://pypi.org/simple/ cssd
+          python -c "
+          import numpy as np
+          from cssd import cssd
+          from importlib.metadata import version
+          x = np.linspace(0, 1, 16)
+          out = cssd(x, np.zeros(16), p=0.99, gamma=1e10)
+          print(f'cssd {version(\"cssd\")} verify OK')
+          "


### PR DESCRIPTION
## Summary

Adds a post-publish smoke check to the publish job: after `gh-action-pypi-publish` finishes, the workflow does a real `pip install cssd` from `pypi.org/simple/`, imports the module, and runs a tiny `cssd(np.linspace(0,1,16), np.zeros(16), p=0.99, gamma=1e10)` call to exercise the Rust binding.

PyPI accepting the upload is not the same as \`pip install\` working. The check catches:
- A renamed module / wrong package name in the workflow (the bug that was silent on CMF for years against the unrelated placeholder \`your-package-name\`)
- Broken `__init__.py`
- ABI / manylinux mismatch
- Missing or broken native binding (Rust extension via PyO3 here)

This mirrors the step that landed in `CircleMedianFilter` during v0.1.7. Same backport landing in parallel for Pottslab, L1TV, DCEBE.

## Test plan

- [ ] First real exercise: next `v*` tag push.
- [ ] Smoke call mirrors what `tests_py/` already exercises.