### PR TITLE
Bump to v1.0.2 (metadata maintenance release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to `cssd` are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-05-11
+
+Metadata maintenance release. No algorithmic changes.
+
+### Changed
+
+- README harmonised with the lab-repo family: badge block, TL;DR sentence, expanded "See also" section linking the five sibling repos and two external related projects, License footer.
+- `CITATION.cff` updated to `version: 1.0.2`, `date-released: 2026-05-11`.
+- Auto-create GitHub Release on tag push (alongside PyPI publish).
+- PyPI publish step set to `skip-existing: true` so workflow re-runs are idempotent.
+
 ## [1.0.1] - 2026-05-07
 
 First PyPI release. Continues the version line of the MATLAB reference

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite both the software and the associated paper below."
 title: "CSSD: Cubic smoothing splines for discontinuous signals"
-version: 1.0.1
-date-released: 2026-05-07
+version: 1.0.2
+date-released: 2026-05-11
 abstract: "Reference implementation (MATLAB and Rust/Python port) of cubic smoothing splines for signals with a priori unknown discontinuities. Solves a piecewise smoothing-spline model in which both the spline coefficients and the discontinuity set are estimated jointly via dynamic programming."
 type: software
 url: "https://github.com/mstorath/CSSD"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cssd-core", "crates/cssd-py"]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cssd"
-version = "1.0.1"
+version = "1.0.2"
 description = "Cubic smoothing splines for discontinuous signals (CSSD)"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/python/cssd/__init__.py
+++ b/python/cssd/__init__.py
@@ -11,4 +11,4 @@ from .cv import cssd_cv, CssdCvOutput
 from .ppform import PiecewisePoly
 
 __all__ = ["cssd", "cssd_cv", "CssdOutput", "CssdCvOutput", "PiecewisePoly"]
-__version__ = "1.0.1"
+__version__ = "1.0.2"


### PR DESCRIPTION
## Summary

Phase 3 maintenance release for CSSD. No algorithmic changes.

Aligns all release-version surfaces in one commit per the new CLAUDE.md release-management rule:

- `pyproject.toml::version` → `1.0.2`
- Workspace `Cargo.toml::version` → `1.0.2` (inherited by `cssd-core` and `cssd-py`)
- `python/cssd/__init__.py::__version__` → `"1.0.2"`
- `CITATION.cff` → `version: 1.0.2`, `date-released: 2026-05-11`
- `CHANGELOG.md` → new `## [1.0.2] - 2026-05-11` entry

## What landed in this version

- README harmonised across the lab repo family (Pass F) — light-touch update since CSSD already followed the family template; added badge block, TL;DR, expanded "See also" to 5 siblings + 2 external.
- Auto-create GitHub Release on tag push wired up.
- PyPI publish step set to `skip-existing: true` for idempotency.

## After merge

Tag `v1.0.2` on the merge commit and push the tag. The auto-release workflow handles PyPI publish + GitHub Release creation.

## Test plan
- [ ] Release workflow runs to completion on tag push
- [ ] PyPI shows `cssd 1.0.2` with the harmonised README rendering correctly